### PR TITLE
Support Erlang/OTP 29

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
     name: OTP ${{matrix.otp}}
     strategy:
       matrix:
-        otp: ['28', '27', '26']
-        rebar3: ['3.25.0']
+        otp: ['29', '28', '27']
+        rebar3: ['3.27.0']
     runs-on: 'ubuntu-24.04'
     steps:
       - uses: actions/checkout@v4
@@ -27,24 +27,24 @@ jobs:
         with:
           path: |
             _build
-          key: ${{ runner.os }}-build-${{ matrix.otp_version }}-${{ hashFiles(format('rebar.lock')) }}-1
+          key: ${{ runner.os }}-build-${{ matrix.otp }}-${{ hashFiles(format('rebar.lock')) }}-1
           restore-keys: |
-            ${{ runner.os }}-build-${{ matrix.otp_version }}-1-
+            ${{ runner.os }}-build-${{ matrix.otp }}-1-
       - run: rebar3 compile
       - run: rebar3 ct
       - run: rebar3 fmt --check
-        if: ${{ matrix.otp == '28' }}
+        if: ${{ matrix.otp == '29' }}
       - run: rebar3 lint
-        if: ${{ matrix.otp == '28' }}
+        if: ${{ matrix.otp == '29' }}
       - run: rebar3 dialyzer
-        if: ${{ matrix.otp == '28' }}
+        if: ${{ matrix.otp == '29' }}
       - run: rebar3 xref
-        if: ${{ matrix.otp == '28' }}
+        if: ${{ matrix.otp == '29' }}
       - run: rebar3 as test do cover, covertool generate
-        if: ${{ matrix.otp == '28' }}
+        if: ${{ matrix.otp == '29' }}
       - name: Upload code coverage
         uses: codecov/codecov-action@v5
-        if: ${{ matrix.otp == '28' }}
+        if: ${{ matrix.otp == '29' }}
         with:
           files: _build/test/covertool/segmented_cache.covertool.xml
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,8 @@ jobs:
         with:
           path: |
             _build
-          key: ${{ runner.os }}-build-${{ matrix.otp }}-${{ hashFiles(format('rebar.lock')) }}-1
-          restore-keys: |
-            ${{ runner.os }}-build-${{ matrix.otp }}-1-
+          key: ${{ runner.os }}-build-${{ matrix.otp }}-${{ hashFiles(format('rebar.lock')) }}
+          restore-keys: ${{ runner.os }}-build-${{ matrix.otp }}-
       - run: rebar3 compile
       - run: rebar3 ct
       - run: rebar3 fmt --check

--- a/rebar.config
+++ b/rebar.config
@@ -23,7 +23,7 @@
 {project_plugins, [
     {rebar3_hex, "~> 7.0"},
     {rebar3_ex_doc, "~> 0.2"},
-    {rebar3_lint, "~> 4.0"},
+    {rebar3_lint, "~> 5.0"},
     {erlfmt, "~> 1.6"},
     {covertool, "~> 2.0"}
 ]}.
@@ -74,18 +74,18 @@
 ]}.
 
 {elvis, [
-    #{
-        dirs => ["src"],
-        filter => "*.erl",
-        ruleset => erl_files,
-        rules => [
-            {elvis_style, export_used_types, disable},
-            {elvis_style, private_data_types, disable}
-        ]
-    },
-    #{
-        dirs => ["."],
-        filter => "rebar.config",
-        ruleset => rebar_config
-    }
+    {config, [
+        #{
+            files => ["src/*.erl"],
+            ruleset => erl_files,
+            rules => [
+                {elvis_style, export_used_types, disable},
+                {elvis_style, private_data_types, disable}
+            ]
+        },
+        #{
+            files => ["rebar.config"],
+            ruleset => rebar_config
+        }
+    ]}
 ]}.

--- a/src/segmented_cache_helpers.erl
+++ b/src/segmented_cache_helpers.erl
@@ -92,7 +92,7 @@ is_member(Name, Key) when is_atom(Name) ->
         Value = iterate_fun_in_tables(
             SegmentRecord, Key, fun segmented_cache_callbacks:is_member_ets_fun/2
         ),
-        {Value, #{name => Name, type => is_member, hit => Value =:= true}}
+        {Value, #{name => Name, type => is_member, hit => Value}}
     end,
     telemetry:span(Prefix, #{name => Name, type => is_member}, Span).
 


### PR DESCRIPTION
Updates CI/release workflows, upgrades linter, and fixes linter warnings.

Also, fixes caching issue (there was no such thing as `matrix.otp_version`, the `-1-` was incorrectly placed).